### PR TITLE
Allow access to entity manager from repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ $registry->add('my-client', $client);
 $configuration = new Configuration();
 $configuration->setMetadataFactory(new EntityMetadataFactory());
 $configuration->setRegistry($this->registry);
-$configuration->setEntityFactoryClass(ProxyFactory::class);
 $configuration->setProxyDir(CACHE_DIR . '/doctrine/proxy/');
 $configuration->setProxyNamespace('MyVendor\Api\Proxy');
 $driver = new MappingDriverChain();

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "symfony/property-access": "~2.3|~3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.5|~5.1",
+    "phpunit/phpunit": "~4.5 ||~5.1, <5.4",
     "scaytrase/json-rpc-client": "~1.0, >=1.0.1"
   },
   "suggest": {

--- a/src/Bankiru/Api/Doctrine/EntityRepository.php
+++ b/src/Bankiru/Api/Doctrine/EntityRepository.php
@@ -114,4 +114,12 @@ class EntityRepository implements ObjectRepository
     {
         return $this->metadata;
     }
+
+    /**
+     * @return EntityManager
+     */
+    public function getManager()
+    {
+        return $this->manager;
+    }
 }

--- a/src/Bankiru/Api/Tests/AbstractEntityManagerTest.php
+++ b/src/Bankiru/Api/Tests/AbstractEntityManagerTest.php
@@ -59,7 +59,7 @@ abstract class AbstractEntityManagerTest extends \PHPUnit_Framework_TestCase
     protected function createEntityManager($clients = [self::DEFAULT_CLIENT])
     {
         /** @var IdGeneratorInterface|\PHPUnit_Framework_MockObject_MockObject $idGenerator */
-        $idGenerator = self::getMock(IdGeneratorInterface::class);
+        $idGenerator = $this->getMock(IdGeneratorInterface::class);
         $idGenerator->method('getRequestIdentifier')->willReturn('test');
 
         $this->registry = new ClientRegistry();


### PR DESCRIPTION
* minor readme fix

This allows i.e. to manually hydrate entities from custom RPC responses.